### PR TITLE
Fix grim + slurp syntax error

### DIFF
--- a/src/transformers_ocr.sh
+++ b/src/transformers_ocr.sh
@@ -61,7 +61,7 @@ else
 	if_installed grim slurp wl-copy || exit 1
 
 	take_screenshot() {
-		grim -g "$(slurp)"
+		grim -g "$(slurp)" -
 	}
 
 	print_platform() {


### PR DESCRIPTION
Without the `-`, this would create screenshots in the current directory from which the `transformers_ocr` command is run, rather than the screenshot path supplied to it.

I found this error by looking through Kein_R's fork and noting the differences: https://github.com/KeinR/transformers_ocr/blob/main/transformers_ocr.sh