### PR TITLE
fix: slurp is not working on GNOME desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Install the following dependencies if they are not installed.
 
 </details>
 
+<details>
+
+<summary>GNOME</summary>
+
+* [pip](https://pypi.org/project/pip/)
+* [gnome-screenshot](https://gitlab.gnome.org/GNOME/gnome-screenshot)
+* [wl-copy](https://github.com/bugaevc/wl-clipboard)
+
+</details>
+
 **Install using Makefile:**
 
 ```

--- a/src/transformers_ocr.sh
+++ b/src/transformers_ocr.sh
@@ -23,6 +23,10 @@ is_Xorg() {
 	[[ ${WAYLAND_DISPLAY:-None} == None ]]
 }
 
+is_GNOME() {
+	[[ ${XDG_CURRENT_DESKTOP:-None} == GNOME ]]
+}
+
 notify() {
 	echo "$*"
 	notify-send "Maim OCR" "$*" &
@@ -51,17 +55,27 @@ if is_Xorg; then
 	if_installed maim xclip || exit 1
 
 	take_screenshot() {
-		maim --select --hidecursor --format=png --quality 1
+		maim --select --hidecursor --format=png --quality 1 "$1"
 	}
 
 	print_platform() {
 		echo "Xorg"
 	}
+elif is_GNOME; then
+	if_installed gnome-screenshot wl-copy || exit 1
+
+	take_screenshot() {
+		gnome-screenshot -a -f "$1"
+	}
+
+	print_platform() {
+		echo "GNOME"
+	}
 else
 	if_installed grim slurp wl-copy || exit 1
 
 	take_screenshot() {
-		grim -g "$(slurp)" -
+		grim -g "$(slurp)" - > "$1"
 	}
 
 	print_platform() {
@@ -80,8 +94,8 @@ prepare_pipe() {
 
 run_ocr() {
 	ensure_listening
-	local -r screenshot_path=$(mktemp /tmp/screenshot.XXXXXX)
-	take_screenshot >"$screenshot_path"
+	local -r screenshot_path=$(mktemp /tmp/screenshot.XXXXXX.png)
+	take_screenshot "$screenshot_path"
 	echo "$1::$screenshot_path" >"$PIPE_PATH" &
 }
 

--- a/src/transformers_ocr.sh
+++ b/src/transformers_ocr.sh
@@ -75,7 +75,7 @@ else
 	if_installed grim slurp wl-copy || exit 1
 
 	take_screenshot() {
-		grim -g "$(slurp)" - > "$1"
+		grim -g "$(slurp)" "$1"
 	}
 
 	print_platform() {


### PR DESCRIPTION
I got an error (see: https://github.com/emersion/slurp/issues/38) when running the script on GNOME desktop env, but I found a workaround using `gnome-screenshot`.

However, `gnome-screenshot` cli is slightly different than `maim` & `grim`. I rewrote the function `take_screenshot`. Also `gnome-screenshot` assumes file type by ext name, so I added `.png` as a suffix of the tmp file.