### PR TITLE
Disable notifications for Spectacle when taking a screenshot

### DIFF
--- a/src/transformers_ocr.py
+++ b/src/transformers_ocr.py
@@ -110,7 +110,7 @@ def gnome_screenshot_select(screenshot_path: str):
 def spectactle_select(screenshot_path: str):
     raise_if_missing("spectacle")
     return subprocess.run(
-        ("spectacle", "-b", "-r", "-o", screenshot_path,),
+        ("spectacle", "-n", "-b", "-r", "-o", screenshot_path,),
         check=True,
         stderr=subprocess.DEVNULL
     )


### PR DESCRIPTION
When using this program, it waits until the spectacle notification disappears before it starts working, if "show notification" is turned off, it works as it should.